### PR TITLE
Use encryption by default for Congress API queries

### DIFF
--- a/applications/find-my-rep/scripts/views/appView.js
+++ b/applications/find-my-rep/scripts/views/appView.js
@@ -85,7 +85,7 @@ App.Views.AppView = Backbone.View.extend({
         locationParams = locationParams.split(",");
         var latitude = parseFloat(locationParams[0]);
         var longitude = parseFloat(locationParams[1]);
-        var urlPrefix = "http://congress.api.sunlightfoundation.com/legislators/locate?";
+        var urlPrefix = "https://congress.api.sunlightfoundation.com/legislators/locate?";
         var testValue = "latitude=" + latitude + "&longitude=" + longitude;
         var urlSuffix = "&apikey=1ca05f19ff1e4e6a87b32bdff29fee95&callback=?";
         var targetUrl = urlPrefix + testValue + urlSuffix;


### PR DESCRIPTION
This changes the protocol for Congress API queries to use `https://`, so that queries are encrypted. You can read more about why we recommend using our encrypted endpoint -- especially for location queries -- in our recent blog post:

https://sunlightfoundation.com/blog/2014/01/28/encrypting-our-congress-api-and-protecting-your-location/
